### PR TITLE
Custom Timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,3 @@ DEPENDENCIES
   rspec (~> 3.1.0, >= 3.1.0)
   rubocop (~> 0.27.0, >= 0.27.1)
   yard (~> 0.8.0, >= 0.8.7)
-
-BUNDLED WITH
-   1.10.3

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Heartcheck.setup do |config|
                   proxy: "10.20.30.40:8888",
                   headers: { "MY-API-KEY" => "abc123" },
                   body_match: /OK/,
-                  ignore_ssl_cert: true)
+                  ignore_ssl_cert: true,
+                  timeout: 60)
   end
 end
 ```

--- a/lib/heartcheck/checks/webservice.rb
+++ b/lib/heartcheck/checks/webservice.rb
@@ -83,7 +83,8 @@ module Heartcheck
                                                service[:proxy],
                                                service[:ignore_ssl_cert],
                                                service[:headers],
-                                               service[:timeout]).get
+                                               service[:open_timeout],
+                                               service[:read_timeout]).get
       end
     end
   end

--- a/lib/heartcheck/checks/webservice.rb
+++ b/lib/heartcheck/checks/webservice.rb
@@ -82,7 +82,8 @@ module Heartcheck
         Heartcheck::Webservice::HttpClient.new(service[:url],
                                                service[:proxy],
                                                service[:ignore_ssl_cert],
-                                               service[:headers]).get
+                                               service[:headers],
+                                               service[:timeout]).get
       end
     end
   end

--- a/lib/heartcheck/webservice/http_client.rb
+++ b/lib/heartcheck/webservice/http_client.rb
@@ -3,9 +3,9 @@ module Heartcheck
   module Webservice
     # Http Client
     class HttpClient
-      attr_reader :uri, :http, :proxy, :headers, :request, :timeout
+      attr_reader :uri, :http, :proxy, :headers, :request, :open_timeout, :read_timeout
 
-      def initialize(url, proxy, ignore_ssl_cert, headers, timeout = nil)
+      def initialize(url, proxy, ignore_ssl_cert, headers, open_timeout = nil, read_timeout = nil)
         @uri = URI(url)
         @headers = headers || {}
         @proxy = URI(proxy) if proxy
@@ -13,7 +13,8 @@ module Heartcheck
         @http = Net::HTTP.new(@uri.host, @uri.port, proxy_host, proxy_port)
         @http.use_ssl = @uri.scheme == 'https'
         @http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ignore_ssl_cert
-        @http.open_timeout = timeout if timeout
+        @http.open_timeout = open_timeout if open_timeout
+        @http.read_timeout = read_timeout if read_timeout
       end
 
       def get

--- a/lib/heartcheck/webservice/http_client.rb
+++ b/lib/heartcheck/webservice/http_client.rb
@@ -3,9 +3,9 @@ module Heartcheck
   module Webservice
     # Http Client
     class HttpClient
-      attr_reader :uri, :http, :proxy, :headers, :request
+      attr_reader :uri, :http, :proxy, :headers, :request, :timeout
 
-      def initialize(url, proxy, ignore_ssl_cert, headers)
+      def initialize(url, proxy, ignore_ssl_cert, headers, timeout = nil)
         @uri = URI(url)
         @headers = headers || {}
         @proxy = URI(proxy) if proxy
@@ -13,6 +13,7 @@ module Heartcheck
         @http = Net::HTTP.new(@uri.host, @uri.port, proxy_host, proxy_port)
         @http.use_ssl = @uri.scheme == 'https'
         @http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ignore_ssl_cert
+        @http.open_timeout = timeout if timeout
       end
 
       def get

--- a/spec/heartcheck/webservice/http_client_spec.rb
+++ b/spec/heartcheck/webservice/http_client_spec.rb
@@ -43,10 +43,16 @@ describe Heartcheck::Webservice::HttpClient do
     end
 
     context 'when timeout' do
-      it 'sets timeout' do
+      it 'sets open timeout' do
         expect_any_instance_of(Net::HTTP).to receive(:open_timeout=)
           .with(2)
         described_class.new(uri, nil, true, nil, 2)
+      end
+
+      it 'sets read timeout' do
+        expect_any_instance_of(Net::HTTP).to receive(:read_timeout=)
+          .with(5)
+        described_class.new(uri, nil, true, nil, nil, 5)
       end
     end
   end

--- a/spec/heartcheck/webservice/http_client_spec.rb
+++ b/spec/heartcheck/webservice/http_client_spec.rb
@@ -4,15 +4,15 @@ describe Heartcheck::Webservice::HttpClient do
   let(:url) { 'http://test.com' }
   let(:uri) { URI url }
   let(:subject) { described_class.new(url, nil, false, nil) }
-  let(:proxy_path) { "http://10.20.30.40:8888" }
+  let(:proxy_path) { 'http://10.20.30.40:8888' }
 
   describe '#initialize' do
     let(:http) { double.as_null_object }
 
-    context "with http proxy" do
-      it "initializes Net::HTTP with a proxy configured" do
+    context 'with http proxy' do
+      it 'initializes Net::HTTP with a proxy configured' do
         expect(Net::HTTP).to receive(:new)
-          .with(uri.host, uri.port, "10.20.30.40", 8888)
+          .with(uri.host, uri.port, '10.20.30.40', 8888)
           .and_return(http)
         described_class.new(url, proxy_path, false, nil)
       end
@@ -41,18 +41,27 @@ describe Heartcheck::Webservice::HttpClient do
         described_class.new(uri, nil, true, nil)
       end
     end
+
+    context 'when timeout' do
+      it 'sets timeout' do
+        expect_any_instance_of(Net::HTTP).to receive(:open_timeout=)
+          .with(2)
+        described_class.new(uri, nil, true, nil, 2)
+      end
+    end
   end
 
   describe '#get' do
-    context "with headers" do
-      subject { described_class.new(url, nil, false, "X-API-KEY" => "123abc") }
+    context 'with headers' do
+      subject { described_class.new(url, nil, false, 'X-API-KEY' => '123abc') }
 
-      it "uses the given headers in the request" do
-        expect_any_instance_of(Net::HTTP).to receive(:request).and_return(double)
+      it 'uses the given headers in the request' do
+        expect_any_instance_of(Net::HTTP).to receive(:request)
+          .and_return(double)
 
         subject.get
 
-        expect(subject.request["X-API-KEY"]).to eq("123abc")
+        expect(subject.request['X-API-KEY']).to eq('123abc')
       end
     end
 


### PR DESCRIPTION
Heartcheck Webservice doesn't have a timeout control, implemented in this PR. I had this problem when I made a resquest to an offline proxy and took a long time causing an HTTP 504 - Timeout in load balance.

In this PR:
- I've added optional argument 'timeout'
- It sets 'open_timeout' attribute to Net:HTTP object
- I've corrected some Rubocop offenses