### PR TITLE
Fix heartcheck dependency version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.7
-  - 2.2.4
-  - 2.3.0
 install: bundle install -j 4 --retry 3
 script:
   - RAILS_ENV=test bundle exec rspec spec
+matrix:
+  include:
+    - rvm: "1.9.3"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.0.0"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.1.7"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.2.1"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.2.4"
+    - rvm: "2.3.3"
+    - rvm: "2.4.1"

--- a/Gemfile-old-ruby
+++ b/Gemfile-old-ruby
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'heartcheck', '~> 1.0.0', '>= 1.0.0'
+
+gem 'pry-nav', '~> 0.2.0', '>= 0.2.4'
+gem 'rspec', '~> 3.1.0', '>= 3.1.0'
+gem 'fakeweb', '~> 1.3.0', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heartcheck-webservice (1.3.0)
+    heartcheck-webservice (1.3.1)
       heartcheck (~> 1.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    heartcheck-webservice (1.2.0)
-      heartcheck (~> 1.0.0, >= 1.0.0)
+    heartcheck-webservice (1.3.0)
+      heartcheck (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,11 +13,13 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     fakeweb (1.3.0)
-    heartcheck (1.0.3)
-      oj (~> 2.11.0, >= 2.11.4)
-      rack (~> 1, >= 1.4.0)
+    heartcheck (1.2.1)
+      multi_json (~> 1.0)
+      net-telnet (~> 0.1.1)
+      rack (>= 1.4.0, < 2.1)
     method_source (0.8.2)
-    oj (2.11.5)
+    multi_json (1.12.1)
+    net-telnet (0.1.1)
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
     powerpack (0.0.9)
@@ -27,7 +29,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    rack (1.6.1)
+    rack (2.0.3)
     rainbow (2.0.0)
     redcarpet (3.2.2)
     rspec (3.1.0)
@@ -63,3 +65,6 @@ DEPENDENCIES
   rspec (~> 3.1.0, >= 3.1.0)
   rubocop (~> 0.27.0, >= 0.27.1)
   yard (~> 0.8.0, >= 0.8.7)
+
+BUNDLED WITH
+   1.15.1

--- a/heartcheck-webservice.gemspec
+++ b/heartcheck-webservice.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'heartcheck', '~> 1.0.0', '>= 1.0.0'
+  spec.add_dependency 'heartcheck', '~> 1.0'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'
   spec.add_development_dependency 'rspec', '~> 3.1.0', '>= 3.1.0'

--- a/lib/heartcheck/webservice/version.rb
+++ b/lib/heartcheck/webservice/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Webservice
-    VERSION = '1.3.0'
+    VERSION = '1.3.1'
   end
 end


### PR DESCRIPTION
### Motivation

We are trying to update rails version to 5 in one of our applications, but we stuck at this point, because this gem requires an old version of heartcheck.

### Solution

Make more flexible the heartcheck version in `gemspec`.

### Comments

We didn't find any guidelines about how to bump versions, so we decided to do it in this merge request.