### PR TITLE
Implement #uri_info to comply with Inspect endpoint

### DIFF
--- a/lib/heartcheck/checks/webservice.rb
+++ b/lib/heartcheck/checks/webservice.rb
@@ -12,6 +12,20 @@ module Heartcheck
         end
       end
 
+      # list services uri info
+      #
+      # @return [Array]
+      def uri_info
+        services.map do |s|
+          uri = URI(s[:url])
+          {
+            host: uri.host,
+            port: uri.port,
+            scheme: uri.scheme
+          }
+        end
+      end
+
       private
 
       DEFAULT_OPEN_TIMEOUT = 3

--- a/spec/heartcheck/checks/webservice_spec.rb
+++ b/spec/heartcheck/checks/webservice_spec.rb
@@ -8,6 +8,24 @@ describe Heartcheck::Checks::Webservice do
     described_class.new.tap { |c| c.add_service(service) }
   end
 
+  describe '#uri_info' do
+    let(:another_service) { { name: 'someservice', url: 'https://another.com', body_match: /OK/ } }
+
+    before do
+      subject.add_service(another_service)
+    end
+
+    context 'when uri data is provided' do
+      it 'returns proper URI info for each checked webservice' do
+        response = subject.uri_info
+        expect(response).to eq([
+                                 { host: 'test.com', port: 80, scheme: 'http' },
+                                 { host: 'another.com', port: 443, scheme: 'https' }
+                               ])
+      end
+    end
+  end
+
   describe '#validate' do
     context 'when there is no error' do
       before do


### PR DESCRIPTION
This change overrides the generic method implemented by https://github.com/locaweb/heartcheck/pull/26

Signed-off-by: Luiz Cavalcanti <luiz.cavalcanti@locaweb.com.br>