### PR TITLE
Add support for ruby 2.5 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       gemfile: Gemfile-old-ruby
     - rvm: "2.2.1"
       gemfile: Gemfile-old-ruby
-    - rvm: "2.2.4"
-    - rvm: "2.3.3"
-    - rvm: "2.4.1"
+    - rvm: 2.2
+    - rvm: 2.3
+    - rvm: 2.4
+    - rvm: 2.5
+    - rvm: 2.6


### PR DESCRIPTION
Change travis.yml to: 
- run tests for ruby 2.5 and 2.6
- get the latest version of some ruby versions
