### PR TITLE
Setting body_match as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [2.2.0] - Unreleased
+## Changed
+- Checks response body only if a `body_match` is defined
+
 ## [2.1.0] - 2018-11-29
 ## Added
 - Custom implementation of Check#uri_info to provide webservices connectivity info

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heartcheck-webservice (2.1.0)
+    heartcheck-webservice (2.2.0)
       heartcheck (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -25,18 +25,28 @@ Or install it yourself as:
 
 You can add a check to a webservice when configuring heartcheck
 
-The service is a Hash that needs to respond to `:name` to identify the service, `:url` of the service (GET request) and `:body_match` is a regex that is going to match the response body.
+The service is a Hash that needs to respond to `:name` to identify the service and `:url` of the service (GET request).
 Ex.
 
 ```ruby
 Heartcheck.setup do |config|
   config.add :webservice do |c|
-    c.add_service(name: 'CloudApi', url: "http://cloud.example.com/status", body_match: /OK/)
+    c.add_service(name: 'CloudApi', url: "http://cloud.example.com/status")
   end
 end
 ```
 
-Here is an example using all available options:
+### Other available options for the service Hash
+* body_match
+  * A regex that is going to match the response body
+* ignore_ssl_cert
+  * When set to `true` the SSL certificate won't be verified
+* open_timeout
+  * Number of seconds to wait for the connection to open
+* read_timeout
+  * Number of seconds to wait for one block to be read
+
+### Here is an example using all available options:
 
 ```ruby
 Heartcheck.setup do |config|

--- a/lib/heartcheck/checks/webservice.rb
+++ b/lib/heartcheck/checks/webservice.rb
@@ -88,7 +88,9 @@ module Heartcheck
       #
       # @return [Bollean]
       def valid_body?(response, service)
-        service[:body_match] && response.body =~ service[:body_match]
+        return true unless service[:body_match]
+
+        response.body =~ service[:body_match]
       end
 
       # execute request

--- a/lib/heartcheck/webservice/version.rb
+++ b/lib/heartcheck/webservice/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Webservice
-    VERSION = '2.1.0'
+    VERSION = '2.2.0'
   end
 end

--- a/spec/heartcheck/checks/webservice_spec.rb
+++ b/spec/heartcheck/checks/webservice_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Heartcheck::Checks::Webservice do
   let(:url) { 'http://test.com' }
   let(:name) { 'test' }
-  let(:service) { { name: name, url: url, body_match: /OK/ } }
+  let(:service) { { name: name, url: url } }
   subject do
     described_class.new.tap { |c| c.add_service(service) }
   end
@@ -28,8 +28,11 @@ describe Heartcheck::Checks::Webservice do
 
   describe '#validate' do
     context 'when there is no error' do
+      let(:another_service) { {name: 'anotherservice', url: 'https://myservice.com', body_match: /OK/ } }
+
       before do
-        FakeWeb.register_uri(:get, url,
+        subject.add_service(another_service)
+        FakeWeb.register_uri(:get, /#{url}|#{another_service[:url]}/,
                              body: 'OK',
                              status: '200')
         subject.validate


### PR DESCRIPTION
As suggested on #8, the response's body will be checked only if a `body_match` is defined. Otherwise only the status code will be taken into account.